### PR TITLE
Create alarm in Root account not Users account

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# cool-users-new-user-alarm #
+# cool-root-new-user-alarm #
 
-[![GitHub Build Status](https://github.com/cisagov/cool-users-new-user-alarm/workflows/build/badge.svg)](https://github.com/cisagov/cool-users-new-user-alarm/actions)
+[![GitHub Build Status](https://github.com/cisagov/cool-users-new-user-alarm/workflows/build/badge.svg)](https://github.com/cisagov/cool-root-new-user-alarm/actions)
 
 This is a Terraform deployment for creating a CloudWatch alarm that is
 triggered when a new user is created.
@@ -18,12 +18,14 @@ triggered when a new user is created.
 |------|---------|
 | aws | ~> 3.38 |
 | aws.organizationsreadonly | ~> 3.38 |
-| aws.usersprovisionaccount | ~> 3.38 |
+| aws.rootprovisionaccount | ~> 3.38 |
 | terraform | n/a |
 
 ## Modules ##
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| sns\_new\_user\_alarms | github.com/cisagov/cw-alarm-sns-tf-module | n/a |
 
 ## Resources ##
 
@@ -36,15 +38,14 @@ No modules.
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.provisionalarm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_organizations_organization.cool](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |
-| [terraform_remote_state.master](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
-| [terraform_remote_state.users](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+| [terraform_remote_state.root](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 
 ## Inputs ##
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | aws\_region | The AWS region to deploy into (e.g. us-east-1). | `string` | `"us-east-1"` | no |
-| provisionaccount\_role\_name | The name of the IAM role that allows sufficient permissions to provision all AWS resources in the Users account. | `string` | `"ProvisionAccount"` | no |
+| provisionaccount\_role\_name | The name of the IAM role that allows sufficient permissions to provision all AWS resources in the Root account. | `string` | `"ProvisionAccount"` | no |
 | provisionalarm\_policy\_description | The description to associate with the IAM policy that allows provisioning of the CloudWatch alarm triggered when a new user is added. | `string` | `"Allows provisioning of the CloudWatch alarm triggered when a new user is added."` | no |
 | provisionalarm\_policy\_name | The name to assign the IAM policy that allows provisioning of the CloudWatch alarm triggered when a new user is added. | `string` | `"ProvisionAlarm"` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |

--- a/alarm.tf
+++ b/alarm.tf
@@ -1,6 +1,6 @@
 # Create a metric filter that feeds the alarm
 resource "aws_cloudwatch_log_metric_filter" "new_user" {
-  provider = aws.usersprovisionaccount
+  provider = aws.rootprovisionaccount
   depends_on = [
     aws_iam_policy.provisionalarm,
     aws_iam_role_policy_attachment.provisionalarm,
@@ -18,14 +18,12 @@ resource "aws_cloudwatch_log_metric_filter" "new_user" {
 
 # Create the alarm
 resource "aws_cloudwatch_metric_alarm" "new_user" {
-  provider = aws.usersprovisionaccount
+  provider = aws.rootprovisionaccount
 
   alarm_actions = [
-    # This is an SNS topic from ControlTower that alerts the admins
-    # via email
-    "arn:aws:sns:${var.aws_region}:${local.users_account_id}:aws-controltower-SecurityNotifications",
+    module.sns_new_user_alarms.sns_topic.arn,
   ]
-  alarm_description   = "A new user was created in the COOL Users account.  Verify that this is not unexpected."
+  alarm_description   = "A new user was created in one of the COOL accounts.  Verify that this is not unexpected."
   alarm_name          = "UserAccountCreated"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"

--- a/backend.tf
+++ b/backend.tf
@@ -5,6 +5,6 @@ terraform {
     dynamodb_table = "terraform-state-lock"
     profile        = "cool-terraform-backend"
     region         = "us-east-1"
-    key            = "cool-users-new-user-alarm/terraform.tfstate"
+    key            = "cool-root-new-user-alarm/terraform.tfstate"
   }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -6,9 +6,8 @@
 data "aws_caller_identity" "current" {}
 
 # ------------------------------------------------------------------------------
-# Retrieve the information for all accouts in the organization.  This
-# is used to lookup the Users account ID for use in the assume role
-# policy.
+# Retrieve the information for all accounts in the organization.  This
+# is used to lookup the Root account ID for use in the provisionalarm policy.
 # ------------------------------------------------------------------------------
 data "aws_organizations_organization" "cool" {
   provider = aws.organizationsreadonly
@@ -22,9 +21,9 @@ locals {
   # session names.
   caller_user_name = split("/", data.aws_caller_identity.current.arn)[1]
 
-  # Find the Users account by name.
-  users_account_id = [
+  # Find the Root account by name.
+  root_account_id = [
     for x in data.aws_organizations_organization.cool.accounts :
-    x.id if x.name == "Users"
+    x.id if x.name == "CISA-COOL"
   ][0]
 }

--- a/providers.tf
+++ b/providers.tf
@@ -10,12 +10,12 @@ provider "aws" {
   }
 }
 
-# The provider used to create new resources in the Users account.
+# The provider used to create new resources in the Root account.
 provider "aws" {
-  alias  = "usersprovisionaccount"
+  alias  = "rootprovisionaccount"
   region = var.aws_region
   assume_role {
-    role_arn     = data.terraform_remote_state.users.outputs.provisionaccount_role.arn
+    role_arn     = data.terraform_remote_state.root.outputs.provisionaccount_role.arn
     session_name = local.caller_user_name
   }
   default_tags {
@@ -28,7 +28,7 @@ provider "aws" {
   alias  = "organizationsreadonly"
   region = var.aws_region
   assume_role {
-    role_arn     = data.terraform_remote_state.master.outputs.organizationsreadonly_role.arn
+    role_arn     = data.terraform_remote_state.root.outputs.organizationsreadonly_role.arn
     session_name = local.caller_user_name
   }
   default_tags {

--- a/provisionalarm_policy.tf
+++ b/provisionalarm_policy.tf
@@ -1,6 +1,6 @@
 # ------------------------------------------------------------------------------
 # Create the IAM policy that allows all of the permissions necessary
-# to provision the new user CloudWatch alarm in the Users account.
+# to provision the new user CloudWatch alarm in the Root account.
 # ------------------------------------------------------------------------------
 
 data "aws_iam_policy_document" "provisionalarm" {
@@ -10,7 +10,7 @@ data "aws_iam_policy_document" "provisionalarm" {
     ]
 
     resources = [
-      "arn:aws:cloudwatch:${var.aws_region}:${local.users_account_id}:alarm:UserAccountCreated",
+      "arn:aws:cloudwatch:${var.aws_region}:${local.root_account_id}:alarm:UserAccountCreated",
     ]
   }
 
@@ -22,14 +22,14 @@ data "aws_iam_policy_document" "provisionalarm" {
     ]
 
     resources = [
-      "arn:aws:logs:${var.aws_region}:${local.users_account_id}:log-group:aws-controltower/CloudTrailLogs",
-      "arn:aws:logs:${var.aws_region}:${local.users_account_id}:log-group:aws-controltower/CloudTrailLogs:log-stream:",
+      "arn:aws:logs:${var.aws_region}:${local.root_account_id}:log-group:aws-controltower/CloudTrailLogs",
+      "arn:aws:logs:${var.aws_region}:${local.root_account_id}:log-group:aws-controltower/CloudTrailLogs:log-stream:",
     ]
   }
 }
 
 resource "aws_iam_policy" "provisionalarm" {
-  provider = aws.usersprovisionaccount
+  provider = aws.rootprovisionaccount
 
   description = var.provisionalarm_policy_description
   name        = var.provisionalarm_policy_name

--- a/provisionalarm_policy_attachment.tf
+++ b/provisionalarm_policy_attachment.tf
@@ -1,10 +1,10 @@
 # ------------------------------------------------------------------------------
 # Attach to the ProvisionAccount role the IAM policy that allows
-# provisioning of the new user CloudWatch alarm in the Users account.
+# provisioning of the new user CloudWatch alarm in the Root account.
 # ------------------------------------------------------------------------------
 
 resource "aws_iam_role_policy_attachment" "provisionalarm" {
-  provider = aws.usersprovisionaccount
+  provider = aws.rootprovisionaccount
 
   policy_arn = aws_iam_policy.provisionalarm.arn
   role       = var.provisionaccount_role_name

--- a/remote_state.tf
+++ b/remote_state.tf
@@ -4,7 +4,7 @@
 # input data for this configuration.
 # ------------------------------------------------------------------------------
 
-data "terraform_remote_state" "master" {
+data "terraform_remote_state" "root" {
   backend = "s3"
 
   config = {
@@ -14,21 +14,6 @@ data "terraform_remote_state" "master" {
     profile        = "cool-terraform-backend"
     region         = "us-east-1"
     key            = "cool-accounts/master.tfstate"
-  }
-
-  workspace = "production"
-}
-
-data "terraform_remote_state" "users" {
-  backend = "s3"
-
-  config = {
-    encrypt        = true
-    bucket         = "cisa-cool-terraform-state"
-    dynamodb_table = "terraform-state-lock"
-    profile        = "cool-terraform-backend"
-    region         = "us-east-1"
-    key            = "cool-accounts/users.tfstate"
   }
 
   workspace = "production"

--- a/sns.tf
+++ b/sns.tf
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------------------
+# Create an SNS topic in the Root account and subscribe the email associated
+# with the Root account to that topic.
+# ------------------------------------------------------------------------------
+
+module "sns_new_user_alarms" {
+  providers = {
+    aws                         = aws.rootprovisionaccount
+    aws.organizations_read_only = aws.organizationsreadonly
+  }
+  source = "github.com/cisagov/cw-alarm-sns-tf-module"
+
+  topic_display_name = "new_user_alarms"
+  topic_name         = "new_user_alarms"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -12,7 +12,7 @@ variable "aws_region" {
 
 variable "provisionaccount_role_name" {
   type        = string
-  description = "The name of the IAM role that allows sufficient permissions to provision all AWS resources in the Users account."
+  description = "The name of the IAM role that allows sufficient permissions to provision all AWS resources in the Root account."
   default     = "ProvisionAccount"
 }
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR updates this code so that the CloudWatch alarm is created in the Root account, rather than the Users account.  This change has already been reflected with a recent change to the name of this repository from `cool-users-new-user-alarm` to `cool-root-new-user-alarm`.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We recently applied a [Control Tower](https://aws.amazon.com/controltower/) update that routes all CloudTrail logs from our AWS organization to a CloudWatch log group in the Root account.  This means that this "new user" alarm no longer works as originally written because the CloudTrail events are being sent out of the Users account to the Root account.  This PR rectifies that situation.

An added benefit here is that this alarm will now trigger if an IAM (or SSO) user is created in any AWS accounts in our organization, not just the Users account.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Coming soon!

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.



